### PR TITLE
Mzg yfc618 20200703

### DIFF
--- a/spring-session/src/main/java/com/guns21/session/boot/config/HttpSessionConfig.java
+++ b/spring-session/src/main/java/com/guns21/session/boot/config/HttpSessionConfig.java
@@ -1,19 +1,26 @@
 package com.guns21.session.boot.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
-import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.data.redis.config.annotation.web.http.RedisHttpSessionConfiguration;
 import org.springframework.session.web.http.HeaderHttpSessionIdResolver;
 import org.springframework.session.web.http.HttpSessionIdResolver;
+
+import javax.annotation.PostConstruct;
 
 /**
  * Created by ljj on 17/5/24.
  */
 //@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 5)
-@EnableRedisHttpSession
-public class HttpSessionConfig {
+@Configuration
+public class HttpSessionConfig extends RedisHttpSessionConfiguration {
+
+    @Value("${server.servlet.session.timeout:1800}")
+    private int sessionTimeout;
 
     /**
      * 通过header传递session ID.
@@ -32,6 +39,13 @@ public class HttpSessionConfig {
     @ConditionalOnMissingBean(RedisSerializer.class)
     public RedisSerializer springSessionDefaultRedisSerializer() {
         return new GenericJackson2JsonRedisSerializer();
+    }
+
+    @PostConstruct
+    @Override
+    public void init() {
+        super.init();
+        super.setMaxInactiveIntervalInSeconds(sessionTimeout);
     }
 
 }

--- a/spring-session/src/main/java/com/guns21/session/boot/config/HttpSessionConfig.java
+++ b/spring-session/src/main/java/com/guns21/session/boot/config/HttpSessionConfig.java
@@ -19,7 +19,7 @@ import javax.annotation.PostConstruct;
 @Configuration
 public class HttpSessionConfig extends RedisHttpSessionConfiguration {
 
-    @Value("${server.servlet.session.timeout:1800}")
+    @Value("${com.guns21.session.timeout:1800}")
     private int sessionTimeout;
 
     /**

--- a/spring-session/src/main/java/com/guns21/session/boot/config/HttpSessionConfig.java
+++ b/spring-session/src/main/java/com/guns21/session/boot/config/HttpSessionConfig.java
@@ -19,7 +19,8 @@ import javax.annotation.PostConstruct;
 @Configuration
 public class HttpSessionConfig extends RedisHttpSessionConfiguration {
 
-    @Value("${com.guns21.session.timeout:1800}")
+    // unit minutes
+    @Value("${com.guns21.session.timeout:30}")
     private int sessionTimeout;
 
     /**
@@ -45,7 +46,7 @@ public class HttpSessionConfig extends RedisHttpSessionConfiguration {
     @Override
     public void init() {
         super.init();
-        super.setMaxInactiveIntervalInSeconds(sessionTimeout);
+        super.setMaxInactiveIntervalInSeconds(sessionTimeout * 60);
     }
 
 }


### PR DESCRIPTION
修改点：修改HttpSessionConfig类，实现共享session，使用@EnableRedisHttpSession注解的方式改用为继承RedisHttpSessionConfiguration类（两者效果一样），超时时间配置提到application_admin.yml中
原因：使用@EnableRedisHttpSession会是springboot提供的配置SpringSession超时配置（server.servlet.session.timeout失效），只能使用@EnableRedisHttpSession自带的maxInactiveIntervalInSeconds属性进行配置。